### PR TITLE
Prevent losing floating point definitions

### DIFF
--- a/lib/parser.js
+++ b/lib/parser.js
@@ -273,9 +273,6 @@ function getRealValue(value) {
     return value === 'true';
   }
 
-  if (!isNaN(value)) { // numbers
-    return +value;
-  }
   return value;
 }
 

--- a/test/parser.js
+++ b/test/parser.js
@@ -314,7 +314,7 @@ describe('Gradle build file parser', function() {
       });
     });
 
-    it('should be able to parse numbers as numbers', function() {
+    it('should parse numbers as strings', function() {
       var dsl = multiline.stripIndent(function() {/*
              myVar301 1
              myVar402 32
@@ -323,10 +323,10 @@ describe('Gradle build file parser', function() {
              */      });
 
       var expected = {
-        myVar301: 1,
-        myVar402: 32,
-        myVar103: 33,
-        myVar204: 4
+        myVar301: '1',
+        myVar402: '32',
+        myVar103: '33',
+        myVar204: '4'
       };
       return parser.parseText(dsl).then(function(parsedValue) {
         expect(parsedValue).to.deep.equal(expected);
@@ -408,7 +408,7 @@ describe('Gradle build file parser', function() {
 
           versionProps: 'new Properties()',
           defaultConfig: {
-            minSdkVersion: 17,
+            minSdkVersion: '17',
             targetSdkVersion: 'rootProject.ext.targetSdkVersion',
             renderscriptTargetApi: 'rootProject.ext.targetSdkVersion',
             renderscriptSupportModeEnabled: true,
@@ -431,7 +431,7 @@ describe('Gradle build file parser', function() {
 
           productFlavors: {
             dev: {
-              minSdkVersion: 21,
+              minSdkVersion: '21',
               multiDexEnabled: true
             },
             prod: {}


### PR DESCRIPTION
JavaScript numbers do not distinguish between ints and floats, hence a number like `1.0` defined in Gradle would get parsed to `1` in JavaScript. From a practical standpoint, this is a problem if we use it in Android projects where we try to parse an app version string like "1.0" - after parsing, we would have no way to tell whether the version was defined with both a major and minor version. Pending a better solution, we should just provide everything as strings to JavaScript, and let the user decide his own number conversion scheme if needed.