### PR TITLE
Skip function definitions

### DIFF
--- a/lib/parser.js
+++ b/lib/parser.js
@@ -133,7 +133,7 @@ function deepParse(chunk, state, keepFunctionCalls) {
     } else if (isDelimiter(character) && parsingKey) {
       if (isKeyword(tempString)) {
         if (tempString === KEYWORD_DEF) {
-          tempString = fetchDefinedName(chunk, state);
+          tempString = fetchDefinedNameOrSkipFunctionDefinition(chunk, state);
         } else if (tempString === KEYWORD_IF) {
           skipIfBlock(chunk, state);
           currentKey = '';
@@ -141,9 +141,13 @@ function deepParse(chunk, state, keepFunctionCalls) {
           continue;
         }
       }
+
       currentKey = tempString;
       tempString = '';
       parsingKey = false;
+      if (!currentKey) {
+        continue;
+      }
     } else {
       if (!tempString && isDelimiter(character)) {
         continue;
@@ -180,6 +184,37 @@ function skipIfBlock(chunk, state) {
   return curlyBraceCount === 0;
 }
 
+function skipFunctionDefinition(chunk, state) {
+  var start = state.index;
+  var parenthesisNest = 1;
+  var character = chunk[++state.index];
+  while (character !== undefined && parenthesisNest) {
+    if (character === CHAR_LEFT_PARENTHESIS) {
+      parenthesisNest++;
+    } else if (character === CHAR_RIGHT_PARENTHESIS) {
+      parenthesisNest--;
+    }
+
+    character = chunk[++state.index];
+  }
+
+  while (character && character !== CHAR_BLOCK_START) character = chunk[++state.index];
+
+  character = chunk[++state.index];
+  var blockNest = 1;
+  while (character !== undefined && blockNest) {
+    if (character === CHAR_BLOCK_START) {
+      blockNest++;
+    } else if (character === CHAR_BLOCK_END) {
+      blockNest--;
+    }
+
+    character = chunk[++state.index];
+  }
+
+  state.index--;
+}
+
 function parseRepositoryClosure(chunk, state) {
   var out = [];
   var repository = deepParse(chunk, state, true);
@@ -193,20 +228,32 @@ function parseRepositoryClosure(chunk, state) {
   return out;
 }
 
-function fetchDefinedName(chunk, state) {
+function fetchDefinedNameOrSkipFunctionDefinition(chunk, state) {
   var character = 0;
   var temp = '';
+  var isVariableDefinition = true;
   for (var max = chunk.length; state.index < max; state.index++) {
     character = chunk[state.index];
 
     if (character === CHAR_EQUALS) {
+      // Variable definition, break and return name
+      break;
+    } else if (character === CHAR_LEFT_PARENTHESIS) {
+      // Function definition, skip parsing
+      isVariableDefinition = false;
+      skipFunctionDefinition(chunk, state);
       break;
     }
 
     temp += String.fromCharCode(character);
   }
-  var values = temp.trim().split(' ');
-  return values[values.length - 1];
+
+  if (isVariableDefinition) {
+    var values = temp.trim().split(' ');
+    return values[values.length - 1];
+  } else {
+    return '';
+  }
 }
 
 function parseArray(chunk, state) {

--- a/lib/parser.js
+++ b/lib/parser.js
@@ -198,7 +198,9 @@ function skipFunctionDefinition(chunk, state) {
     character = chunk[++state.index];
   }
 
-  while (character && character !== CHAR_BLOCK_START) character = chunk[++state.index];
+  while (character && character !== CHAR_BLOCK_START) {
+    character = chunk[++state.index];
+  }
 
   character = chunk[++state.index];
   var blockNest = 1;

--- a/test/parser.js
+++ b/test/parser.js
@@ -349,6 +349,28 @@ describe('Gradle build file parser', function() {
         expect(parsedValue).to.deep.equal(expected);
       });
     });
+
+    it('can skip function definitions', function() {
+      var dsl = multiline.stripIndent(function() {/*
+             myVar1 "a"
+             def fibonacci (int i) {
+               if (i <= 2) {
+                 return 1;
+               } else {
+                 return fibonacci(i - 1) + fibonacci(i - 2);
+               }
+             }
+             myVar2 "c"
+             */      });
+
+      var expected = {
+        myVar1: 'a',
+        myVar2: 'c'
+      };
+      return parser.parseText(dsl).then(function(parsedValue) {
+        expect(parsedValue).to.deep.equal(expected);
+      });
+    });
     // TODO: Add test for ...
   });
   describe('File parsing', function() {


### PR DESCRIPTION
Adds the ability to skip function definitions. Originally, something like this
```groovy
def fibonacci (int i) {
  if (i <= 2) {
    return 1;
  } else {
    return fibonacci(i - 1) + fibonacci(i - 2);
  }
}
```

would confuse the parser because after seeing the `def` keyword, it would [try to search for an equals sign](https://github.com/ninetwozero/gradle-to-js/blob/master/lib/parser.js#L202) and we end up skipping a lot of things unintentionally.