### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Using `gradle-to-js` as a module, you can parse both strings and files as seen b
 
 ### Files
 ```
-var g2js = import('gradle-to-js');
+var g2js = require('gradle-to-js/lib/parser');
 g2js.parseFile('path/to/buildfile').then(function(representation) {
   console.log(representation);
 });
@@ -24,7 +24,7 @@ g2js.parseFile('path/to/buildfile').then(function(representation) {
 
 ### Strings
 ```
-var g2js = import('gradle-to-js');
+var g2js = require('gradle-to-js/lib/parser');
 g2js.parseText('key "value"').then(function(representation) {
   console.log(representation);
 });


### PR DESCRIPTION
The code that was listed would result in usage as a module not working. You must link directly to the parser in /lib, because the package.json indicates the index.js is the root, which has no export