### PR TITLE
Rework dependency parsing

### DIFF
--- a/lib/parser.js
+++ b/lib/parser.js
@@ -7,6 +7,7 @@ var deepAssign = require('deep-assign')
 
 var exports = module.exports = {};
 
+var CHAR_TAB = 9;
 var CHAR_NEWLINE = 10;
 var CHAR_SPACE = 32;
 var CHAR_LEFT_PARENTHESIS = 40;
@@ -22,6 +23,7 @@ var KEYWORD_DEF = 'def';
 var KEYWORD_IF = 'if';
 
 var WHITESPACE_CHARACTERS = {};
+WHITESPACE_CHARACTERS[CHAR_TAB] = true;
 WHITESPACE_CHARACTERS[CHAR_NEWLINE] = true;
 WHITESPACE_CHARACTERS[CHAR_SPACE] = true;
 
@@ -34,19 +36,13 @@ var SPECIAL_KEYS = {
   dependencies: parseDependencyClosure
 };
 
-var DEPS_LINE_KEYWORDS = {
-  compile: true,
-  runtime: true,
-  testCompile: true,
-  testRuntime: true
-};
-
-var DEPS_KEYWORD_STRING_PATTERN = '[ \\t]*(' + Object.keys(DEPS_LINE_KEYWORDS).join('|') + ')[ \\t]*';
+var DEPS_KEYWORD_STRING_PATTERN = '[ \\t]*([A-Za-z0-9_-]+)[ \\t]*';
 var DEPS_KEYWORD_STRING_REGEX = RegExp(DEPS_KEYWORD_STRING_PATTERN);
 var DEPS_EASY_GAV_STRING_REGEX = RegExp('(["\']?)([\\w.-]+):([\\w.-]+):([\\w.-]+)\\1');
 var DEPS_HARD_GAV_STRING_REGEX = RegExp(DEPS_KEYWORD_STRING_PATTERN + '(?:\\((.*)\\)|(.*))');
 var DEPS_ITEM_BLOCK_REGEX = RegExp(DEPS_KEYWORD_STRING_PATTERN + '\\(((["\']?)(.*)\\3)\\)[ \\t]*\\{');
 var DEPS_EXCLUDE_LINE_REGEX = RegExp('exclude[ \\t]+([^\\n]+)', 'g');
+
 
 function deepParse(chunk, state, keepFunctionCalls, skipEmptyValues) {
   var out = {};
@@ -279,7 +275,9 @@ function parseDependencyClosure(chunk, state) {
         commentText += String.fromCharCode(chunk[state.index]);
       }
     }
-    if (DEPS_LINE_KEYWORDS[currentKey]) {
+
+
+    if (currentKey && isWhitespace(chunk[state.index])) {
       var character = '';
       for (state.index = state.index + 1; state.index < chunk.length; state.index++) {
         character = chunk[state.index];
@@ -296,7 +294,7 @@ function parseDependencyClosure(chunk, state) {
         }
       }
 
-      out.push(createStructureForDependencyItem(currentKey + currentValue));
+      out.push(createStructureForDependencyItem(currentKey + ' ' + currentValue));
       currentKey = '';
       currentValue = '';
     }
@@ -358,10 +356,20 @@ function parseGavString(gavString) {
   } else {
     var hardGavMatches = DEPS_HARD_GAV_STRING_REGEX.exec(gavString);
     if (hardGavMatches && (hardGavMatches[3] || hardGavMatches[2])) {
-      out = parseMapNotation(hardGavMatches[3] || hardGavMatches[2]);
+      out = parseMapNotationWithFallback(out, hardGavMatches[3] || hardGavMatches[2]);
     } else {
-      out = parseMapNotation(gavString);
+      out = parseMapNotationWithFallback(out, gavString, gavString.slice(findFirstSpaceOrTabPosition(gavString)));
     }
+  }
+  return out;
+}
+
+function parseMapNotationWithFallback(out, string, name) {
+  var outFromMapNotation = parseMapNotation(string);
+  if (outFromMapNotation['name']) {
+    out = outFromMapNotation;
+  } else {
+    out['name'] = name ? name : string;
   }
   return out;
 }
@@ -379,7 +387,7 @@ function parseMapNotation(input) {
       for (var innerLoop = 0, i = i + 1; i < max; i++) {
         if (innerLoop === 0) {
           // Skip any leading spaces before the actual value
-          if (isWhitespace(input[i])) {
+          if (isWhitespaceLiteral(input[i])) {
             continue;
           }
         }
@@ -531,6 +539,10 @@ function isDelimiter(character) {
 
 function isWhitespace(character) {
   return WHITESPACE_CHARACTERS.hasOwnProperty(character);
+}
+
+function isWhitespaceLiteral(character) {
+  return isWhitespace(character.charCodeAt(0));
 }
 
 function isKeyword(string) {

--- a/lib/parser.js
+++ b/lib/parser.js
@@ -25,9 +25,28 @@ var WHITESPACE_CHARACTERS = {};
 WHITESPACE_CHARACTERS[CHAR_NEWLINE] = true;
 WHITESPACE_CHARACTERS[CHAR_SPACE] = true;
 
+var SINGLE_LINE_COMMENT_START = '//';
+var BLOCK_COMMENT_START = '/*';
+var BLOCK_COMMENT_END = '*/';
+
 var SPECIAL_KEYS = {
-  repositories: parseRepositoryClosure
+  repositories: parseRepositoryClosure,
+  dependencies: parseDependencyClosure
 };
+
+var DEPS_LINE_KEYWORDS = {
+  compile: true,
+  runtime: true,
+  testCompile: true,
+  testRuntime: true
+};
+
+var DEPS_KEYWORD_STRING_PATTERN = '[ \\t]*(' + Object.keys(DEPS_LINE_KEYWORDS).join('|') + ')[ \\t]*';
+var DEPS_KEYWORD_STRING_REGEX = RegExp(DEPS_KEYWORD_STRING_PATTERN);
+var DEPS_EASY_GAV_STRING_REGEX = RegExp('(["\']?)([\\w.-]+):([\\w.-]+):([\\w.-]+)\\1');
+var DEPS_HARD_GAV_STRING_REGEX = RegExp(DEPS_KEYWORD_STRING_PATTERN + '(?:\\((.*)\\)|(.*))');
+var DEPS_ITEM_BLOCK_REGEX = RegExp(DEPS_KEYWORD_STRING_PATTERN + '\\(((["\']?)(.*)\\3)\\)[ \\t]*\\{');
+var DEPS_EXCLUDE_LINE_REGEX = RegExp('exclude[ \\t]+([^\\n]+)', 'g');
 
 function deepParse(chunk, state, keepFunctionCalls, skipEmptyValues) {
   var out = {};
@@ -228,6 +247,174 @@ function skipFunctionDefinition(chunk, state) {
   state.index--;
 }
 
+
+function parseDependencyClosure(chunk, state) {
+  var out = [];
+
+  // openBlockCount starts at 1 due to us entering after "dependencies {"  
+  var openBlockCount = 1;
+  var currentKey = '';
+  var currentValue = '';
+
+  var isInItemBlock = false;
+  for (; state.index < chunk.length; state.index++) {
+    if (chunk[state.index] === CHAR_BLOCK_START) {
+      openBlockCount++;
+    } else if (chunk[state.index] === CHAR_BLOCK_END) {
+      openBlockCount--;
+    } else {
+      currentKey += String.fromCharCode(chunk[state.index]);
+    }
+
+    // Keys shouldn't have any leading nor trailing whitespace
+    currentKey = currentKey.trim();
+
+    if (isStartOfComment(currentKey)) {
+      var commentText = currentKey;
+      for (state.index = state.index + 1; state.index < chunk.length; state.index++) {
+        if (isCommentComplete(commentText, chunk[state.index])) {
+          currentKey = '';
+          break;
+        }
+        commentText += String.fromCharCode(chunk[state.index]);
+      }
+    }
+    if (DEPS_LINE_KEYWORDS[currentKey]) {
+      var character = '';
+      for (state.index = state.index + 1; state.index < chunk.length; state.index++) {
+        character = chunk[state.index];
+        currentValue += String.fromCharCode(character);
+        
+        if (character === CHAR_BLOCK_START) {
+          isInItemBlock = true;
+        } else if (isInItemBlock && character === CHAR_BLOCK_END) {
+          isInItemBlock = false;
+        } else if (!isInItemBlock) {
+          if (character === CHAR_NEWLINE && currentValue) {
+            break;
+          }
+        }
+      }
+
+      out.push(createStructureForDependencyItem(currentKey + currentValue));
+      currentKey = '';
+      currentValue = '';
+    }
+
+    if (openBlockCount == 0) {
+      break;
+    }
+  }
+  return out;
+}
+
+function createStructureForDependencyItem(data) {
+  var out = { group: '', name: '', version: '', type: '' };
+  var compileBlockInfo = findDependencyItemBlock(data);
+  if (compileBlockInfo['gav']) {
+    out = parseGavString(compileBlockInfo['gav']);
+    out['type'] = compileBlockInfo['type'];
+    out['excludes'] = compileBlockInfo['excludes'];
+  } else {
+    out = parseGavString(data);
+    out['type'] = DEPS_KEYWORD_STRING_REGEX.exec(data)[1] || '';
+    out['excludes'] = [];
+  }
+  return out;
+}
+
+function findFirstSpaceOrTabPosition(input) {
+  var position = input.indexOf(' ');
+  if (position === -1) {
+    position = input.indexOf('\t');
+  }
+  return position;
+}
+
+function findDependencyItemBlock(data) {
+  var matches = DEPS_ITEM_BLOCK_REGEX.exec(data);
+  if (matches && matches[2]) {
+    var excludes = [];
+
+    var match;
+    while((match = DEPS_EXCLUDE_LINE_REGEX.exec(data))) {
+      excludes.push(parseMapNotation(match[0].substring(findFirstSpaceOrTabPosition(match[0]))));
+    }
+    
+    return { gav: matches[2], type: matches[1], excludes: excludes };
+  }
+  return [];
+}
+
+function parseGavString(gavString) {
+  var out = { group: '', name: '', version: '' };
+  var easyGavStringMatches = DEPS_EASY_GAV_STRING_REGEX.exec(gavString);
+  if (easyGavStringMatches) {
+    out['group'] = easyGavStringMatches[2];
+    out['name'] = easyGavStringMatches[3];
+    out['version'] = easyGavStringMatches[4];
+  } else if (gavString.indexOf('project(') !== -1) {
+    out['name'] = gavString.match(/(project\([^\)]+\))/g)[0];
+  } else {
+    var hardGavMatches = DEPS_HARD_GAV_STRING_REGEX.exec(gavString);
+    if (hardGavMatches && (hardGavMatches[3] || hardGavMatches[2])) {
+      out = parseMapNotation(hardGavMatches[3] || hardGavMatches[2]);
+    } else {
+      out = parseMapNotation(gavString);
+    }
+  }
+  return out;
+}
+
+function parseMapNotation(input) {
+  var out = {};
+  var currentKey = '';
+  var quotation = '';
+
+  for (var i = 0, max = input.length; i < max; i++) {
+    if (input[i] === ':') {
+      currentKey = currentKey.trim();
+      out[currentKey] = '';
+
+      for (var innerLoop = 0, i = i + 1; i < max; i++) {
+        if (innerLoop === 0) {
+          // Skip any leading spaces before the actual value
+          if (isWhitespace(input[i])) {
+            continue;
+          }
+        }
+
+        // We just take note of what the "latest" quote was so that we can 
+        if (input[i] === '"' || input[i] === "'") {
+          quotation = input[i];
+          continue;
+        }
+
+        // Moving on to the next value if we find a comma
+        if (input[i] === ',') {
+          out[currentKey] = out[currentKey].trim();
+          currentKey = '';
+          break;
+        }
+
+        out[currentKey] += input[i];
+        innerLoop++;
+      }
+    } else {
+      currentKey += input[i];
+    }
+  }
+
+  // If the last character contains a quotation mark, we remove it
+  if (out[currentKey]) {
+    out[currentKey] = out[currentKey].trim();
+    if (out[currentKey].slice(-1) === quotation) {
+      out[currentKey] = out[currentKey].slice(0, -1);
+    }
+  }
+  return out;
+}
+
 function parseRepositoryClosure(chunk, state) {
   var out = [];
   var repository = deepParse(chunk, state, true, false);
@@ -305,14 +492,6 @@ function skipFunctionCall(chunk, state) {
   return openParenthesisCount === 0;
 }
 
-function isKeyword(string) {
-  return string === KEYWORD_DEF || string === KEYWORD_IF;
-}
-
-function isSingleLineComment(startOfComment) {
-  return startOfComment === '//';
-}
-
 function addValueToStructure(structure, currentKey, value) {
   if (currentKey) {
     if (structure.hasOwnProperty(currentKey)) {
@@ -336,14 +515,6 @@ function getRealValue(value) {
   return value;
 }
 
-function isDelimiter(character) {
-  return character === CHAR_SPACE || character === CHAR_EQUALS;
-}
-
-function isWhitespace(character) {
-  return WHITESPACE_CHARACTERS.hasOwnProperty(character);
-}
-
 function trimWrappingQuotes(string) {
   var firstCharacter = string.slice(0, 1);
   if (firstCharacter === '"') {
@@ -354,12 +525,32 @@ function trimWrappingQuotes(string) {
   return string;
 }
 
+function isDelimiter(character) {
+  return character === CHAR_SPACE || character === CHAR_EQUALS;
+}
+
+function isWhitespace(character) {
+  return WHITESPACE_CHARACTERS.hasOwnProperty(character);
+}
+
+function isKeyword(string) {
+  return string === KEYWORD_DEF || string === KEYWORD_IF;
+}
+
+function isSingleLineComment(comment) {
+  return comment.slice(0, 2) === SINGLE_LINE_COMMENT_START;
+}
+
 function isStartOfComment(snippet) {
-  return snippet === '/*' || snippet === '//';
+  return snippet === BLOCK_COMMENT_START || snippet === SINGLE_LINE_COMMENT_START;
+}
+
+function isCommentComplete(text, next) {
+  return (next === CHAR_NEWLINE && isSingleLineComment(text)) || (isWhitespace(next) && isEndOfMultiLineComment(text));
 }
 
 function isEndOfMultiLineComment(comment) {
-  return comment.indexOf('*/') != -1;
+  return comment.slice(-2) === BLOCK_COMMENT_END;
 }
 
 function parse(readableStream) {

--- a/test/sample-data/muzei.build.gradle
+++ b/test/sample-data/muzei.build.gradle
@@ -123,7 +123,7 @@ dependencies {
     compile 'com.android.support:recyclerview-v7:23.1.1'
     compile 'com.android.support:design:23.1.1'
     compile 'com.android.support:customtabs:23.1.1'
-
+    
     // :api is included as a transitive dependency from :android-client-common
     // compile project(':api')
     compile project(':android-client-common')

--- a/test/sample-data/muzei.build.gradle.expected.js
+++ b/test/sample-data/muzei.build.gradle.expected.js
@@ -8,7 +8,15 @@ exports.expected = {
           type: 'unknown'
         }
       ],
-      dependencies: []
+      dependencies: [
+        {
+          group: '',
+          name: 'rootProject.ext.gradleClasspath',
+          version: '',
+          type: 'classpath',
+          excludes: []
+        }
+      ]
     },
     apply: 'plugin: \'com.android.application\'',
     'project.archivesBaseName': 'muzei',
@@ -158,6 +166,20 @@ exports.expected = {
         name: 'project(\':android-client-common\')',
         version: '',
         type: 'compile',
+        excludes: []
+      },
+      {
+        group: '',
+        name: 'project(path: \':wearable\', configuration: \'devRelease\')',
+        version: '',
+        type: 'devWearApp',
+        excludes: []
+      },
+      {
+        group: '',
+        name: 'project(path: \':wearable\', configuration: \'prodRelease\')',
+        version: '',
+        type: 'prodWearApp',
         excludes: []
       }
     ]

--- a/test/sample-data/muzei.build.gradle.expected.js
+++ b/test/sample-data/muzei.build.gradle.expected.js
@@ -1,12 +1,14 @@
-(function() {
-  return {
+exports.expected = {
     buildscript: {
-      repositories: [
-        'mavenCentral()'
+      repositories: [  
+        {
+          data: {
+            name: 'mavenCentral()'
+          },
+          type: 'unknown'
+        }
       ],
-      dependencies: {
-        classpath: 'rootProject.ext.gradleClasspath'
-      }
+      dependencies: []
     },
     apply: 'plugin: \'com.android.application\'',
     'project.archivesBaseName': 'muzei',
@@ -26,7 +28,7 @@
 
       versionProps: 'new Properties()',
       defaultConfig: {
-        minSdkVersion: 17,
+        minSdkVersion: '17',
         targetSdkVersion: 'rootProject.ext.targetSdkVersion',
         renderscriptTargetApi: 'rootProject.ext.targetSdkVersion',
         renderscriptSupportModeEnabled: true,
@@ -49,7 +51,7 @@
 
       productFlavors: {
         dev: {
-          minSdkVersion: 21,
+          minSdkVersion: '21',
           multiDexEnabled: true
         },
         prod: {}
@@ -87,21 +89,76 @@
       }
     },
 
-    dependencies: {
-      compile: [
-        'com.squareup.okhttp:okhttp:2.1.0',
-        'com.squareup.okhttp:okhttp-urlconnection:2.1.0',
-        'com.squareup.picasso:picasso:2.4.0',
-        'com.google.android.gms:play-services-wearable:8.3.0',
-        'de.greenrobot:eventbus:2.4.0',
-        'com.android.support:appcompat-v7:23.1.1',
-        'com.android.support:recyclerview-v7:23.1.1',
-        'com.android.support:design:23.1.1',
-        'com.android.support:customtabs:23.1.1',
-        'project(\':android-client-common\')'
-      ],
-      devWearApp: 'project(path: \':wearable\', configuration: \'devRelease\')',
-      prodWearApp: 'project(path: \':wearable\', configuration: \'prodRelease\')'
-    }
-  };
-})();
+    dependencies: [
+      {
+        group: 'com.squareup.okhttp',
+        name: 'okhttp',
+        version: '2.1.0',
+        type: 'compile',
+        excludes: []
+      },
+      {
+        group: 'com.squareup.okhttp',
+        name: 'okhttp-urlconnection',
+        version: '2.1.0',
+        type: 'compile',
+        excludes: []
+      },
+      {
+        group: 'com.squareup.picasso',
+        name: 'picasso',
+        version: '2.4.0',
+        type: 'compile',
+        excludes: []
+      },
+      {
+        group: 'com.google.android.gms',
+        name: 'play-services-wearable',
+        version: '8.3.0',
+        type: 'compile',
+        excludes: []
+      },
+      {
+        group: 'de.greenrobot',
+        name: 'eventbus',
+        version: '2.4.0',
+        type: 'compile',
+        excludes: []
+      },
+      {
+        group: 'com.android.support',
+        name: 'appcompat-v7',
+        version: '23.1.1',
+        type: 'compile',
+        excludes: []
+      },
+      {
+        group: 'com.android.support',
+        name: 'recyclerview-v7',
+        version: '23.1.1',
+        type: 'compile',
+        excludes: []
+      },
+      {
+        group: 'com.android.support',
+        name: 'design',
+        version: '23.1.1',
+        type: 'compile',
+        excludes: []
+      },
+      {
+        group: 'com.android.support',
+        name: 'customtabs',
+        version: '23.1.1',
+        type: 'compile',
+        excludes: []
+      },
+      {
+        group: '',
+        name: 'project(\':android-client-common\')',
+        version: '',
+        type: 'compile',
+        excludes: []
+      }
+    ]
+  }

--- a/test/sample-data/special.dependencies.build.gradle
+++ b/test/sample-data/special.dependencies.build.gradle
@@ -1,0 +1,32 @@
+dependencies {
+    compile (project(':react-native-maps')) {
+        exclude group: 'com.google.android.gms', module: 'play-services-base'
+        exclude group: 'com.google.android.gms', module: 'play-services-maps'
+    }
+    testRuntime (project(':react-native-background-geolocation')) {
+        exclude group: 'com.google.android.gms', module: 'play-services-location'
+    }
+    compile (group: 'g0', name: 'a0', version: 'v0') {
+        exclude group: 'com.google.android.gms1'
+        exclude module: 'play-services-location1'
+    }    
+    compile (group: 'g0', name: 'a0', version: 'v0') {
+        exclude group: 'com.google.android.gms1'
+        exclude module: 'play-services-location1'
+    }
+
+
+    /*compile 'g1:a1:v1'
+    runtime group: 'g2', name: 'a2', version: 'v2'
+    compile('g3:a3:v3') {
+        exclude group: 'com.google.android.gms', module: 'play-services-location'
+    }
+
+    compile('com.org.g4:org-a4:org-v4')
+    testCompile (group: 'g5', name: 'a5', version: 'v5')
+    
+    // comment
+    compile project(':project-behind-comment')
+    compile project(':project-behind-comment2')
+    */
+}

--- a/test/sample-data/special.dependencies.build.gradle
+++ b/test/sample-data/special.dependencies.build.gradle
@@ -1,3 +1,13 @@
+buildscript {
+    repositories {
+        mavenCentral()
+    }
+    dependencies {
+        classpath some.classpath.entry
+    }
+}
+
+
 dependencies {
     compile (project(':react-native-maps')) {
         exclude group: 'com.google.android.gms', module: 'play-services-base'
@@ -16,7 +26,7 @@ dependencies {
     }
 
 
-    /*compile 'g1:a1:v1'
+    compile 'g1:a1:v1'
     runtime group: 'g2', name: 'a2', version: 'v2'
     compile('g3:a3:v3') {
         exclude group: 'com.google.android.gms', module: 'play-services-location'
@@ -28,5 +38,8 @@ dependencies {
     // comment
     compile project(':project-behind-comment')
     compile project(':project-behind-comment2')
-    */
+    
+
+    devWearApp project(':wear')
+    prodWearApp project(':wear')
 }


### PR DESCRIPTION
Alright, let's try to get #7 and #8 solved. :-)

Dependency closures are a bit complex, but also something that might be quite important for us to be able to extract properly. Instead of relying on the user having enough knowledge to know what to expect in the parsed data, we leverage what we *think* we know and return all the dependencies we could find in a unified way.

Meaning, all our dependencies will look something like this:

```
{
    group: 'the name of the group',
    name: 'the name of the artifact',
    version: 'the specified version',
    type: 'the type, usually compile or runtime but sometimes custom names',
    excludes: [
        {
            module: 'some module here'
        },
        {
            group: 'some group here'
            module: 'some other module here'
        }
    ]
}
```

That should work quite nicely, if you ask me.

Would you guys care to take a look? @geof90 @sergey-akhalkov @stillesjo @the-simian