### PR TITLE
Add support for IF statements without braces

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,3 +37,10 @@ node_modules
 
 # Vim stuff
 *.swp
+
+# Other IDEs
+.vscode
+*.sublime-workspace
+
+# Misc
+.DS_Store

--- a/lib/parser.js
+++ b/lib/parser.js
@@ -12,6 +12,7 @@ var CHAR_NEWLINE = 10;
 var CHAR_SPACE = 32;
 var CHAR_LEFT_PARENTHESIS = 40;
 var CHAR_RIGHT_PARENTHESIS = 41;
+var CHAR_PERIOD = 46;
 var CHAR_SLASH = 47;
 var CHAR_EQUALS = 61;
 var CHAR_ARRAY_START = 91;
@@ -110,13 +111,20 @@ function deepParse(chunk, state, keepFunctionCalls, skipEmptyValues) {
       skipFunctionCall(chunk, state);
       currentKey = '';
       tempString = '';
+      isBeginningOfLine = true;
       continue;
     }
 
     if (character === CHAR_NEWLINE) {
       if (!currentKey && tempString) {
-        currentKey = tempString;
-        tempString = '';
+        if (parsingKey) {
+          if (isFunctionCall(tempString) && !keepFunctionCalls) {
+            continue;
+          } else {
+            currentKey = tempString.trim();
+            tempString = '';  
+          }  
+        } 
       }
 
       if (tempString || (currentKey && !skipEmptyValues)) {
@@ -142,8 +150,9 @@ function deepParse(chunk, state, keepFunctionCalls, skipEmptyValues) {
     }
 
     if (character === CHAR_BLOCK_START) {
-      state.index++; // We need to skip the start character
-
+      // We need to skip the current (=start) character so that we literally "step into" the next closure/block        
+      state.index++;
+      
       if (SPECIAL_KEYS.hasOwnProperty(currentKey)) {
         out[currentKey] = SPECIAL_KEYS[currentKey](chunk, state);
       } else if (out[currentKey]) {
@@ -161,7 +170,7 @@ function deepParse(chunk, state, keepFunctionCalls, skipEmptyValues) {
         if (tempString === KEYWORD_DEF) {
           tempString = fetchDefinedNameOrSkipFunctionDefinition(chunk, state);
         } else if (tempString === KEYWORD_IF) {
-          skipIfBlock(chunk, state);
+          skipIfStatement(chunk, state);
           currentKey = '';
           tempString = '';
           continue;
@@ -188,23 +197,34 @@ function deepParse(chunk, state, keepFunctionCalls, skipEmptyValues) {
   return out;
 }
 
-function skipIfBlock(chunk, state) {
+function skipIfStatement(chunk, state) {
   skipFunctionCall(chunk, state);
 
   var character = '';
   var hasFoundTheCurlyBraces = false;
+  var hasFoundAStatementWithoutBraces = false;
   var curlyBraceCount = 0;
+
   for (var max = chunk.length; state.index < max; state.index++) {
     character = chunk[state.index];
-    if (character === CHAR_BLOCK_START) {
-      hasFoundTheCurlyBraces = true;
-      curlyBraceCount++;
-    } else if (character === CHAR_BLOCK_END) {
-      curlyBraceCount--;
-    }
 
-    if (hasFoundTheCurlyBraces && curlyBraceCount === 0) {
-      break;
+    if (hasFoundAStatementWithoutBraces) {
+      if (character === CHAR_NEWLINE) {
+        break;
+      }
+    } else {
+      if (character === CHAR_BLOCK_START) {
+        hasFoundTheCurlyBraces = true;
+        curlyBraceCount++;
+      } else if (character === CHAR_BLOCK_END) {
+        curlyBraceCount--;
+      } else if (!hasFoundTheCurlyBraces && !isWhitespace(character)) {
+        hasFoundAStatementWithoutBraces = true;
+      }
+
+      if ((hasFoundTheCurlyBraces && curlyBraceCount === 0)) {
+        break;
+      }
     }
   }
   return curlyBraceCount === 0;
@@ -492,8 +512,8 @@ function skipFunctionCall(chunk, state) {
     } else if (character === CHAR_RIGHT_PARENTHESIS) {
       openParenthesisCount--;
     }
-
-    if (openParenthesisCount === 0) {
+    if (openParenthesisCount === 0 && !isWhitespace(character)) {
+      state.index++;
       break;
     }
   }
@@ -563,6 +583,10 @@ function isCommentComplete(text, next) {
 
 function isEndOfMultiLineComment(comment) {
   return comment.slice(-2) === BLOCK_COMMENT_END;
+}
+
+function isFunctionCall(string) {
+  return string.match(/\w+\(.*\);?$/) !== null;
 }
 
 function parse(readableStream) {

--- a/test/parser.js
+++ b/test/parser.js
@@ -351,6 +351,24 @@ describe('Gradle build file parser', function() {
       });
     });
 
+    it('can skip if clauses without brackets', function() {
+      var dsl = multiline.stripIndent(function() {/*
+             myVar1 "a"
+             if (myBreakfast === "eggs") myVar1 "b"
+             myVar2 "c"
+             if (myBreakfast === "bacon")
+                myVar2 "d"
+             */      });
+
+      var expected = {
+        myVar1: 'a',
+        myVar2: 'c'
+      };
+      return parser.parseText(dsl).then(function(parsedValue) {
+        expect(parsedValue).to.deep.equal(expected);
+      });
+});
+
     it('can skip function definitions', function() {
       var dsl = multiline.stripIndent(function() {/*
              myVar1 "a"


### PR DESCRIPTION
Helpfully brought to our attention in #10, we didn't previously support IF statements without braces, meaning:

```
if (condition) key "value"
```

or even

```
if (condition)
    key "value"
```

This should now work a bit better. @JPeer264, could you take a look at this and see if it seems like I'm doing the right thing?

...one thing's certain - I wouldn't have wanted to write this change without having the current test cases as my partner in crime... the VS Code debugger gets an honorable mention as well. :-)  