### PR TITLE
fix(testCompile): handle multiline declaration

### DIFF
--- a/lib/parser.js
+++ b/lib/parser.js
@@ -334,7 +334,8 @@ function createStructureForDependencyItem(data) {
     out['excludes'] = compileBlockInfo['excludes'];
   } else {
     out = parseGavString(data);
-    out['type'] = DEPS_KEYWORD_STRING_REGEX.exec(data)[1] || '';
+    var parsed = DEPS_KEYWORD_STRING_REGEX.exec(data);
+    out['type'] = (parsed && parsed[1]) || '';
     out['excludes'] = [];
   }
   return out;

--- a/test/parser.js
+++ b/test/parser.js
@@ -564,5 +564,14 @@ describe('Gradle build file parser', function() {
         expect(parsedValue).to.deep.equal(expected);
       });
     });
+
+    it('should be able to parse the testCompile with multiline gradle file', function() {
+      var sampleFilePath = 'test/sample-data/test.compile.build.gradle';
+      var expected = require(process.cwd() + '/test/sample-data/test.compile.build.gradle.expected.js').expected;
+
+      return parser.parseFile(sampleFilePath).then(function(parsedValue) {
+        expect(parsedValue).to.deep.equal(expected);
+      });
+    });    
   });
 });

--- a/test/sample-data/test.compile.build.gradle
+++ b/test/sample-data/test.compile.build.gradle
@@ -1,0 +1,14 @@
+dependencies {
+    testCompile(
+      'junit:junit:4.12',
+      'org.codehaus.groovy:groovy-all:2.4.10'
+      )
+
+    testCompile([
+      'org.jfrog.buildinfo:build-info-extractor-gradle:4.5.4',
+      'com.netflix.nebula:gradle-lint-plugin:latest.release'
+      ]
+      )
+
+    testCompile(org.hibernate:hibernate-core:3.6.7.Final)
+}

--- a/test/sample-data/test.compile.build.gradle
+++ b/test/sample-data/test.compile.build.gradle
@@ -6,8 +6,7 @@ dependencies {
 
     testCompile([
       'org.jfrog.buildinfo:build-info-extractor-gradle:4.5.4',
-      'com.netflix.nebula:gradle-lint-plugin:latest.release'
-      ]
+      'com.netflix.nebula:gradle-lint-plugin:latest.release']
       )
 
     testCompile(org.hibernate:hibernate-core:3.6.7.Final)

--- a/test/sample-data/test.compile.build.gradle.expected.js
+++ b/test/sample-data/test.compile.build.gradle.expected.js
@@ -1,0 +1,46 @@
+exports.expected = {
+    dependencies: [
+      {
+        group: 'junit',
+        name: 'junit',
+        version: '4.12',
+        type: 'testCompile',
+        excludes: []
+      },
+      {
+        group: 'org.codehaus.groovy',
+        name: 'groovy-all',
+        version: '2.4.10',
+        type: 'org',
+        excludes: []
+      },
+      {
+        group: 'org.jfrog.buildinfo',
+        name: 'build-info-extractor-gradle',
+        version: '4.5.4',
+        type: 'testCompile',
+        excludes: []
+      },
+      {
+        group: 'com.netflix.nebula',
+        name: 'gradle-lint-plugin',
+        version: 'latest.release',
+        type: 'com',
+        excludes: []
+      },
+      {
+        group: '',
+        name: ' \n',
+        version: '',
+        type: '',
+        excludes: []
+      },
+      {
+        group: 'org.hibernate',
+        name: 'hibernate-core',
+        version: '3.6.7.Final)',
+        type: 'testCompile',
+        excludes: []
+      }
+    ]
+  }

--- a/test/sample-data/test.compile.build.gradle.expected.js
+++ b/test/sample-data/test.compile.build.gradle.expected.js
@@ -29,13 +29,6 @@ exports.expected = {
         excludes: []
       },
       {
-        group: '',
-        name: ' \n',
-        version: '',
-        type: '',
-        excludes: []
-      },
-      {
         group: 'org.hibernate',
         name: 'hibernate-core',
         version: '3.6.7.Final)',


### PR DESCRIPTION
It was throwing following error for testCompile declared as multiline. `null` case was not handled therefore it was throwing error. 

```
Gradle build file parser
       (file parsing)
         should be able to parse the testCompile with multiline gradle file:
     Uncaught TypeError: Cannot read property '1' of null
      at createStructureForDependencyItem (lib/parser.js:337:55)
      at Object.parseDependencyClosure [as dependencies] (lib/parser.js:316:16)
      at deepParse (lib/parser.js:156:51)
      at ReadStream.<anonymous> (lib/parser.js:618:13)
      at addChunk (_stream_readable.js:288:12)
      at readableAddChunk (_stream_readable.js:269:11)
      at ReadStream.Readable.push (_stream_readable.js:224:10)
      at fs.read (internal/fs/streams.js:183:12)
      at FSReqCallback.wrapper [as oncomplete] (fs.js:479:5)
```