### PR TITLE
Update plugins line pattern to support opt parens

### DIFF
--- a/lib/parser.js
+++ b/lib/parser.js
@@ -45,7 +45,7 @@ var DEPS_EASY_GAV_STRING_REGEX = RegExp('(["\']?)([\\w.-]+):([\\w.-]+):([\\w\\[\
 var DEPS_HARD_GAV_STRING_REGEX = RegExp(DEPS_KEYWORD_STRING_PATTERN + '(?:\\((.*)\\)|(.*))');
 var DEPS_ITEM_BLOCK_REGEX = RegExp(DEPS_KEYWORD_STRING_PATTERN + '\\(((["\']?)(.*)\\3)\\)[ \\t]*\\{');
 var DEPS_EXCLUDE_LINE_REGEX = RegExp('exclude[ \\t]+([^\\n]+)', 'g');
-var PLUGINS_LINE_PATTERN = RegExp('(id|version)(?:[ \\t])(["\']?)([A-Za-z0-9.]+)\\2', 'g');
+var PLUGINS_LINE_PATTERN = RegExp('(id|version)[ \\t]*\\(?(["\']?)([A-Za-z0-9.]+)\\2\\)?', 'g');
 
 
 function deepParse(chunk, state, keepFunctionCalls, skipEmptyValues) {

--- a/test/parser.js
+++ b/test/parser.js
@@ -301,6 +301,9 @@ describe('Gradle build file parser', function() {
                 id 'some.id.here' version 'some.version.here'
                 id 'another.id.here'
                 version 'some.other.version.here' id 'some.other.id.here'
+                id "plugin.id.doublequotes"
+                id ('plugin.id.parens')
+                id ('plugin.id.parens.version') version '1.2.3'
              }
             */});
 
@@ -309,6 +312,9 @@ describe('Gradle build file parser', function() {
             {id: 'some.id.here', version: 'some.version.here'},
             {id: 'another.id.here'},
             {id: 'some.other.id.here', version: 'some.other.version.here'},
+            {id: 'plugin.id.doublequotes'},
+            {id: 'plugin.id.parens'},
+            {id: 'plugin.id.parens.version', version: '1.2.3'}
         ]
       };
       return parser.parseText(dsl).then(function(parsedValue) {


### PR DESCRIPTION
A small update to the plugins line patters, which adds support for optional parentheses.

For example:

```
plugins {
    id ('plugin.id.parens')
}
```

While the parenthese here are redundant (in Groovy), they are valid syntax, and were previously not parsed correctly. Also added a few new test cases. 
This is related to (but does not yet fix) issue #29.