### PR TITLE
Add support for Gradle wildcard

### DIFF
--- a/lib/parser.js
+++ b/lib/parser.js
@@ -45,7 +45,7 @@ var DEPS_EASY_GAV_STRING_REGEX = RegExp('(["\']?)([\\w.-]+):([\\w.-]+):([\\w\\[\
 var DEPS_HARD_GAV_STRING_REGEX = RegExp(DEPS_KEYWORD_STRING_PATTERN + '(?:\\((.*)\\)|(.*))');
 var DEPS_ITEM_BLOCK_REGEX = RegExp(DEPS_KEYWORD_STRING_PATTERN + '\\(((["\']?)(.*)\\3)\\)[ \\t]*\\{');
 var DEPS_EXCLUDE_LINE_REGEX = RegExp('exclude[ \\t]+([^\\n]+)', 'g');
-var PLUGINS_LINE_PATTERN = RegExp('(id|version)[ \\t]*\\(?(["\']?)([A-Za-z0-9._-]+)\\2\\)?', 'g');
+var PLUGINS_LINE_PATTERN = RegExp('(id|version)[ \\t]*\\(?(["\']?)([A-Za-z0-9+._-]+)\\2\\)?', 'g');
 
 
 function deepParse(chunk, state, keepFunctionCalls, skipEmptyValues) {

--- a/test/parser.js
+++ b/test/parser.js
@@ -306,6 +306,7 @@ describe('Gradle build file parser', function() {
                 id 'id.with.underscore_symbol'
                 id ('plugin.id.parens')
                 id ('plugin.id.parens.version') version '1.2.3'
+                id 'plugin.with.plus.wildcard' version '3.2.+'
              }
             */});
 
@@ -318,7 +319,8 @@ describe('Gradle build file parser', function() {
             {id: 'id.with.hyphen-symbol'},
             {id: 'id.with.underscore_symbol'},
             {id: 'plugin.id.parens'},
-            {id: 'plugin.id.parens.version', version: '1.2.3'}
+            {id: 'plugin.id.parens.version', version: '1.2.3'},
+            {id: 'plugin.with.plus.wildcard', version: '3.2.+'}
         ]
       };
       return parser.parseText(dsl).then(function(parsedValue) {


### PR DESCRIPTION
Currently a plugin block of 

```gradle
plugins {
    id 'org.springframework.boot' version '3.2.+'
    id 'io.spring.dependency-management' version '1.1.+'
}
```

Outputs

```json
plugins: [
  {id: 'org.springframework.boot'},
  {id: 'io.spring.dependency-management'}
]
```

without the versions. This add support to return the versions.  The new output would be

```json
plugins: [
  {id: 'org.springframework.boot', version: '3.2.+'},
  {id: 'io.spring.dependency-management', version: '1.1.+'}
]
```